### PR TITLE
Allow other docker images

### DIFF
--- a/src/roboco/configurations.py
+++ b/src/roboco/configurations.py
@@ -28,6 +28,7 @@ class ProjectConfiguration:
     robot: Robot
     ros_distro: ROSDistro
     hardware: list[HardwareOption]
+    base_image: str
 
 
 realsense_camera = HardwareOption("realsense_camera", "RealSense Camera", ["melodic", "noetic", "foxy", "humble"])

--- a/src/roboco/template.py
+++ b/src/roboco/template.py
@@ -28,6 +28,12 @@ def generate_from_template(configuration: ProjectConfiguration, destination: Pat
     shutil.copyfile(run_script_src, run_script_dest)
     os.chmod(run_script_dest, 0o755)  # noqa: S103
 
+    base_ros_image = f"osrf/ros:{configuration.ros_distro}-desktop-full"
+    if configuration.base_image != base_ros_image:
+        with open(f"{package_dir}/templates/ros/DockerfileAuto") as f:
+            new_template = f"FROM {configuration.base_image}\n" + f.read()
+            replace_string_in_file(dockerfile_dest, f"FROM {base_ros_image}", new_template)
+
     replace_string_in_file(Path(run_script_dest), "please_change_project_name", configuration.name)
     add_to_beginning_of_file(Path(dockerfile_dest), f"# Generated using roboco version {__version__}\n")
 

--- a/src/roboco/templates/ros/DockerfileAuto
+++ b/src/roboco/templates/ros/DockerfileAuto
@@ -1,0 +1,39 @@
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Update package information and install necessary dependencies
+RUN apt-get update && apt-get install -y lsb-release curl
+# Echo the Bash script into a file inside the container
+
+RUN echo '#!/bin/bash \n\
+    lookup_ros_version() { \n\
+    \tcase $1 in \n\
+    \t\t"focal") echo "noetic" ;; \n\
+    \t\t"bionic") echo "melodic" ;; \n\
+    \t\t"xenial") echo "kinetic" ;; \n\
+    \t\t"trusty") echo "indigo" ;; \n\
+    \t\t*) echo "Unsupported Ubuntu version" ;; \n\
+    \tesac \n\
+    } \n\
+    ubuntu_version=$(lsb_release -sc) \n\
+    export ROS_VERSION=$(lookup_ros_version "$ubuntu_version")\
+    ' >> version.sh && \
+    chmod +x version.sh
+
+RUN . ./version.sh && \
+    sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' && \
+    curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install ros-$ROS_VERSION-desktop-full && \
+    apt-get install python-rosdep && \
+    rosdep init && rosdep update && \
+    echo "source /opt/ros/$ROS_VERSION/setup.bash" >> ~/.bashrc
+
+# Install additional dependencies
+RUN apt-get install -y \
+    python-rosinstall \
+    python-rosinstall-generator \
+    python-wstool \
+    build-essential
+
+# Clean up
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/src/roboco/utils.py
+++ b/src/roboco/utils.py
@@ -1,0 +1,11 @@
+import docker
+
+
+def check_docker_image_exists(image_name: str):
+    client = docker.from_env()
+    try:
+        print("Downloading image....")
+        client.images.pull(image_name)
+        return True
+    except docker.errors.ImageNotFound:
+        return False


### PR DESCRIPTION
This is kind of hacky, but would be super useful. I can specify other docker images as a base e.g., "nvcr.io/nvidia/pytorch:23.04-py3" so i do not need to install cuda on top of the container. I added a template which will basically install the correct version of ros by looking at the ubuntu version. Only have the ROS 1 template for now